### PR TITLE
Fix compilation on some systems

### DIFF
--- a/src/commonui/CExtListInputDialog.cpp
+++ b/src/commonui/CExtListInputDialog.cpp
@@ -1,6 +1,7 @@
 #include "CExtListInputDialog.h"
 #include "ui_CExtListInputDialog.h"
 
+#include <QAbstractItemView>
 
 CExtListInputDialog::CExtListInputDialog(QWidget *parent) :
     QDialog(parent),


### PR DESCRIPTION
This adds a missing include, which prevented compilation on my system (Gentoo, Qt 5.11.3-r2, gcc 6.4.0).

The error was
```
CExtListInputDialog.cpp: In constructor ‘CExtListInputDialog::CExtListInputDialog(QWidget*)’:
CExtListInputDialog.cpp:11:22: error: invalid use of incomplete type ‘class QAbstractItemView’
  ui->comboBox->view()->setAlternatingRowColors(true);
```