### PR TITLE
macOS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,9 +80,16 @@ cd <directory-with-qvgeapp.pro>
 qmake-qt5 -r
 ~~~
 
+or, for macOS (with Homebrew and XCode Command Line Tools):
+~~~
+brew install qt
+cd <directory-with-qvgeapp.pro>
+/usr/local/Cellar/qt/5.*/bin/qmake -r
+~~~
+
 Then run corresponding 'make' command to build the application: 
 
-Linux GCC:
+Linux GCC, macOS Clang:
 ~~~
 make
 ~~~

--- a/README.md
+++ b/README.md
@@ -157,13 +157,13 @@ Recent version of **QVGE** has been built with:
 - MinGW 7.3
 - GCC 7.5 (Linux)
 - GCC 6.4.0 (Cygwin)
-- Clang C++ (FreeBSD)
+- Clang C++ (FreeBSD, macOS)
 
 Hopefully it can also be compiled with others compilers. If not please do not hesitate to provide description of the issue.
 
 ### Supported OS
 
-**QVGE** has been tested on Microsoft Windows 10 and several Linux OS (Mint, Mageia, Fedora etc). Theoretically it should run on (almost) any OS which have Qt 5.x installed.
+**QVGE** has been tested on Microsoft Windows 10, several Linux distributions (Mint, Mageia, Fedora etc) and macOS 11.2 Big Sur. Theoretically it should run on (almost) any OS which have Qt 5.x installed.
 
 **QVGE** can be compiled & run under Cygwin.
 

--- a/src/app.pri
+++ b/src/app.pri
@@ -43,7 +43,7 @@ win32{
 
 
 unix{
-    !haiku{
+    !if(haiku|mac){
         QT += x11extras
         LIBS += -lX11
     }

--- a/src/appbase/CPlatformServices.cpp
+++ b/src/appbase/CPlatformServices.cpp
@@ -108,7 +108,7 @@ quint64 CPlatformServices::GetTotalRAMBytes()
 
 #endif // windows
 
-#if (defined(Q_OS_LINUX) || defined (Q_OS_UNIX) || defined (Q_OS_CYGWIN)) && (!defined (Q_OS_HAIKU))
+#if (defined(Q_OS_LINUX) || defined (Q_OS_UNIX) || defined (Q_OS_CYGWIN)) && (!defined (Q_OS_HAIKU)) && (!defined (Q_OS_DARWIN))
 
 #include <QProcessInfo>
 
@@ -208,7 +208,7 @@ quint64 CPlatformServices::GetTotalRAMBytes()
 
 
 // haiku
-#if defined (Q_OS_HAIKU)
+#if (defined(Q_OS_HAIKU) || defined(Q_OS_DARWIN))
 
 quint64 CPlatformServices::GetTotalRAMBytes()
 {

--- a/src/appbase/appbase.pri
+++ b/src/appbase/appbase.pri
@@ -5,10 +5,11 @@ FORMS       += $$files($$PWD/*.ui)
 RESOURCES   += $$files($$PWD/*.qrc)
 
 unix{
-    !haiku{
+    !if(haiku|mac){
         QT += x11extras
         LIBS += -lX11
-
+    }
+    !haiku {
         SOURCES += $$PWD/../3rdParty/qprocessinfo/qprocessinfo.cpp
         HEADERS += $$PWD/../3rdParty/qprocessinfo/qprocessinfo.h
         INCLUDEPATH += $$PWD/../3rdParty/qprocessinfo


### PR DESCRIPTION
I successfully built and used QVGE in macOS 11.2 (Big Sur) and wanted to upstream the necessary changes - this makes the application truly cross-plattform among the most used Desktop OS (Win, Mac, Linux).
Only basic features were tested (graph creation, modification, saving, opening, etc.).

Maybe QVGE could be included in Homebrew, too.

Please note Haiku support is untested with these changes, but I took special care not to modify the build regarding these includes or definitions.

![macos](https://user-images.githubusercontent.com/6495713/108090377-d530d380-707a-11eb-8ddb-0b8a5a7baf70.png)

