### PR TITLE
Fix licenses

### DIFF
--- a/src/3rdParty/qtpropertybrowser/LICENSE
+++ b/src/3rdParty/qtpropertybrowser/LICENSE
@@ -1,0 +1,28 @@
+Copyright (C) 2013 Digia Plc and/or its subsidiary(-ies).
+Contact: http://www.qt-project.org/legal
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+  * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+  * Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in
+    the documentation and/or other materials provided with the
+    distribution.
+  * Neither the name of Digia Plc and its Subsidiary(-ies) nor the names
+    of its contributors may be used to endorse or promote products derived
+    from this software without specific prior written permission.
+
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/src/qvgeapp/linux/qvge.appdata.xml
+++ b/src/qvgeapp/linux/qvge.appdata.xml
@@ -3,9 +3,7 @@
 <component type="desktop">
   <id>qvge.desktop</id>
   <metadata_license>MIT</metadata_license>
-  <project_license>MIT</project_license>
-  <project_license>BSD</project_license>
-  <project_license>LGPL-3.0</project_license>
+  <project_license>MIT AND BSD-2-Clause AND BSD-3-Clause AND LGPL-3.0-only</project_license>
   <name>Qt visual graph editor</name>
   <summary>View and manipulate small till middle-sized graphs.</summary>
   <description>


### PR DESCRIPTION
Licensing related fixes related to #151. The motivation for this comes from the [ongoing effort to include qvge in Fedora][fedora]. Fedora has strict rules to ensure clear and correct licensing.

1. Add separate LICENSE file for the bundled qtpropertybrowser library to make binary packaging in distributions like Fedora Linux easier. The license is already included at the beginning of all source files, but this is not enough because the used BSD 3 Clause license requires including a copy of the license with the binary. On the other hand, a separate file with only qtpropertybrowser's license text is easy to package with the binary.
2. According to AppStream specification, component metadata can contain no more than one project_license field and multiple licenses must be encoded using AND operator within that field. Changed to that format. Also, corrected license names to use valid SPDX license identifiers as required by the specification. Also, made the distinction between BSD-2-Clause and BSD-3-Clause. qprocessinfo uses the 2 clause version while qtpropertybrowser uses the 3 clause version.

EDIT: Since I claim that the old AppStream metadata was invalid, I guess it is the best include a link to the relevant specification: [AppStream project_license][spec].

[fedora]: https://bugzilla.redhat.com/show_bug.cgi?id=1913870
[spec]: https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-project_license