### PR TITLE
docs: Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,10 +82,12 @@ qmake-qt5 -r
 
 or, for macOS (with Homebrew and XCode Command Line Tools):
 ~~~
-brew install qt
+brew install qt@5
 cd <directory-with-qvgeapp.pro>
-/usr/local/Cellar/qt/5.*/bin/qmake -r
+/usr/local/Cellar/qt@5/5.*/bin/qmake -r
 ~~~
+
+(Note: your path to Cellar might differ depending on your homebrew install)
 
 Then run corresponding 'make' command to build the application: 
 


### PR DESCRIPTION
- Change brew formula to qt@5 (since `brew install qt` defaults to version 6.1.1)
- Small note for brew Cellar locations (e.g. on M1 it's in `/opt/homebrew`)