### PR TITLE
fix when layouting node name contain space

### DIFF
--- a/src/qvgeio/CFormatPlainDOT.cpp
+++ b/src/qvgeio/CFormatPlainDOT.cpp
@@ -175,6 +175,7 @@ static QStringList parseLine(QTextStream &ts)
 			while (line[i] != '"' && line[i] != '\0')
 				token += line[i++];
 			tokens << token;
+			i++;
 
 			goto _loop;
 		}


### PR DESCRIPTION
like a node with name: "copy of 1"