### PR TITLE
Fix build issue on VS2019 #165

### DIFF
--- a/src/qvge/qvge.pro
+++ b/src/qvge/qvge.pro
@@ -15,6 +15,7 @@ win32{
 	QMAKE_TARGET_COPYRIGHT = (C) 2016-2020 Ars L. Masiuk
 	QMAKE_TARGET_DESCRIPTION = Qt Visual Graph Editor
 	QMAKE_TARGET_PRODUCT = qvge
+	LIBS += -ladvapi32
 }
 
 


### PR DESCRIPTION
Missing library to linker results in error "Unresolved external symbols __imp__RegCloseKey" and similar